### PR TITLE
Also add scenario to flows

### DIFF
--- a/src/structures/tulipa-asset.jl
+++ b/src/structures/tulipa-asset.jl
@@ -12,7 +12,7 @@ mutable struct TulipaAsset{KeyType}
     milestone_year_data::PerYear{Dict{Symbol,Any}}
     both_years_data::PerYears{Dict{Symbol,Any}}
 
-    profiles::Dict{Tuple{ProfileType,Int,Int},Vector{Float64}}
+    profiles::Dict{Tuple{ProfileType,Int,ScenarioType},Vector{Float64}}
 
     partitions::Dict{Tuple{Int,Int},Dict{Symbol,Any}}
 

--- a/src/structures/tulipa-data.jl
+++ b/src/structures/tulipa-data.jl
@@ -7,7 +7,6 @@ export TulipaData,
     attach_both_years_data!,
     attach_profile!,
     add_asset_group!,
-    attach_profile!,
     set_partition!
 
 """
@@ -305,11 +304,12 @@ function attach_profile!(
     to_asset_name::KeyType,
     profile_type::ProfileType,
     year::Int,
-    profile_value::Vector,
+    profile_value::Vector;
+    scenario::Int = DEFAULT_SCENARIO,
 ) where {KeyType}
     add_or_update_year!(tulipa, year, length = length(profile_value), is_milestone = true)
     flow = tulipa.graph[from_asset_name, to_asset_name]
-    attach_profile!(flow, profile_type, year, profile_value)
+    attach_profile!(flow, profile_type, year, profile_value; scenario = scenario)
     return tulipa
 end
 

--- a/src/structures/tulipa-flow.jl
+++ b/src/structures/tulipa-flow.jl
@@ -11,7 +11,7 @@ mutable struct TulipaFlow{KeyType}
     milestone_year_data::PerYear{Dict{Symbol,Any}}
     both_years_data::PerYears{Dict{Symbol,Any}}
 
-    profiles::Dict{Tuple{ProfileType,Int},Vector{Float64}}
+    profiles::Dict{Tuple{ProfileType,Int,ScenarioType},Vector{Float64}}
 
     partitions::Dict{Tuple{Int,Int},Dict{Symbol,Any}}
 
@@ -86,13 +86,14 @@ function attach_profile!(
     flow::TulipaFlow,
     profile_type::ProfileType,
     year::Int,
-    profile_value::Vector,
+    profile_value::Vector;
+    scenario::Int = DEFAULT_SCENARIO,
 )
-    key = (profile_type, year)
+    key = (profile_type, year, scenario)
     if haskey(flow.profiles, key)
         throw(
             ExistingKeyError(
-                "Profile of type '$profile_type' for year '$year' already attached",
+                "Profile of type '$profile_type' for year '$year' and scenario '$scenario' already attached",
             ),
         )
     end


### PR DESCRIPTION
Scenario in the flow are necessary because the current implementation
of scenario in assets creates the scenario column every time.
The TulipaEnergyModel tests of commodity profiles fail because of it.

Related to https://github.com/TulipaEnergy/TulipaEnergyModel.jl/issues/1483
